### PR TITLE
Update SDK tools and add GitLab CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS
+
+## Commit message format
+
+Follow these concise rules for commit messages. No prefixes in the subject or body. Keep it useful; stop explaining the code twice.
+
+- **Subject**: limit to 50 characters. Keep it short and specific.
+- **Separate** the subject from the body with a single blank line.
+- **Capitalize** the subject line.
+- **Do not** end the subject line with a period.
+- **Use the imperative mood** in the subject (e.g., "Fix bug", "Add test").
+- **Body**: expected only if it is really necessary and provides value that the subject cannot convey. When present, explain *what* and *why*, not *how*. Provide context and rationale; the code shows how.
+
+### Example
+
+```text
+Summarize changes in around 50 characters or less
+
+More detailed explanatory text, if necessary. Explain why the change was made and any non-obvious side effects.
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:latest
 
-RUN apt update && apt upgrade -y && apt install openjdk-17-jdk wget unzip -y
+RUN apt-get update && apt-get upgrade -y && apt-get install openjdk-17-jdk wget unzip -y
 
-ENV ANDROID_HOME /opt/android
-ENV PATH ${PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools
+ENV ANDROID_HOME=/opt/android
+ENV PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools
 
 RUN mkdir $ANDROID_HOME
 
@@ -27,12 +27,12 @@ RUN echo "y" | sdkmanager "extras;google;m2repository"
 RUN echo "y" | sdkmanager "platforms;android-36"
 RUN echo "y" | sdkmanager --update
 
-RUN apt install git curl iputils-ping dnsutils jsonnet -y \
+RUN apt-get install git curl iputils-ping dnsutils jsonnet -y \
   && wget -q https://gitlab.com/gitlab-org/cli/-/releases/v1.67.0/downloads/glab_1.67.0_linux_amd64.tar.gz \
   && tar -xzf glab_1.67.0_linux_amd64.tar.gz \
   && mv bin/glab /usr/local/bin/ \
   && rm -rf glab_1.67.0_linux_amd64.tar.gz bin CHANGELOG.md LICENSE README.md
-RUN apt autoremove -y && apt clean
+RUN apt-get autoremove -y && apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 
 RUN ln -s $ANDROID_HOME /usr/lib/android-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH ${PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platfo
 
 RUN mkdir $ANDROID_HOME
 
-RUN wget https://dl.google.com/android/repository/commandlinetools-linux-10406996_latest.zip -qO android-sdk.zip \
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-13114758_latest.zip -qO android-sdk.zip \
   && unzip android-sdk.zip -d $ANDROID_HOME \
   && mkdir $ANDROID_HOME/tmp/ \
   && mv $ANDROID_HOME/cmdline-tools/* $ANDROID_HOME/tmp \
@@ -18,15 +18,20 @@ RUN wget https://dl.google.com/android/repository/commandlinetools-linux-1040699
 
 RUN echo "y" | sdkmanager "tools"
 RUN echo "y" | sdkmanager "platform-tools"
+RUN echo "y" | sdkmanager "build-tools;35.0.0"
 RUN echo "y" | sdkmanager "build-tools;34.0.0"
 RUN echo "y" | sdkmanager "build-tools;33.0.2"
 RUN echo "y" | sdkmanager "build-tools;33.0.1"
 RUN echo "y" | sdkmanager "extras;android;m2repository"
 RUN echo "y" | sdkmanager "extras;google;m2repository"
-RUN echo "y" | sdkmanager "platforms;android-33"
+RUN echo "y" | sdkmanager "platforms;android-36"
 RUN echo "y" | sdkmanager --update
 
-RUN apt install git curl iputils-ping dnsutils jsonnet -y
+RUN apt install git curl iputils-ping dnsutils jsonnet -y \
+  && wget -q https://gitlab.com/gitlab-org/cli/-/releases/v1.67.0/downloads/glab_1.67.0_linux_amd64.tar.gz \
+  && tar -xzf glab_1.67.0_linux_amd64.tar.gz \
+  && mv bin/glab /usr/local/bin/ \
+  && rm -rf glab_1.67.0_linux_amd64.tar.gz bin CHANGELOG.md LICENSE README.md
 RUN apt autoremove -y && apt clean
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,10 @@ RUN echo "y" | sdkmanager "platforms;android-36"
 RUN echo "y" | sdkmanager --update
 
 RUN apt-get install git curl iputils-ping dnsutils jsonnet -y \
-  && wget -q https://gitlab.com/gitlab-org/cli/-/releases/v1.67.0/downloads/glab_1.67.0_linux_amd64.tar.gz \
-  && tar -xzf glab_1.67.0_linux_amd64.tar.gz \
-  && mv bin/glab /usr/local/bin/ \
-  && rm -rf glab_1.67.0_linux_amd64.tar.gz bin CHANGELOG.md LICENSE README.md
+  && wget -q https://gitlab.com/gitlab-org/cli/-/releases/v1.67.0/downloads/glab_1.67.0_linux_amd64.tar.gz -O /tmp/glab.tar.gz \
+  && tar -xzf /tmp/glab.tar.gz -C /tmp \
+  && mv /tmp/bin/glab /usr/local/bin/ \
+  && rm -rf /tmp/glab.tar.gz /tmp/bin /tmp/CHANGELOG.md /tmp/LICENSE /tmp/README.md
 RUN apt-get autoremove -y && apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ Preinstalled tools/components:
 Tool/Component | Version
 ------- | -------
 OpenJDK | 17
-Android SDK Build-Tools | 34.0.0, 33.0.2, 33.0.1
-Android SDK Platform | 33
-Git | 2.34.1
-Curl | 7.81.0
-Jsonnet | 0.17.0
+Android SDK Build-Tools | 35.0.0, 34.0.0, 33.0.2, 33.0.1
+Android SDK Platform | 36
+Git | 2.43.0
+Curl | 8.5.0
+Jsonnet | 0.20.0
+GitLab CLI | 1.67.0
 iputils-ping |
 dnsutils |
 


### PR DESCRIPTION
## Summary
- add Android build-tools 35.0.0 and target platform 36
- update git, curl, jsonnet versions in README
- install GitLab CLI and latest command line tools